### PR TITLE
(BRH-389): Fix `/workspaces/{workspace_id}` endpoint error bug

### DIFF
--- a/bmh_admin_portal_backend/lambda/workspaces_api_resource/workspaces_api_resource_handler.py
+++ b/bmh_admin_portal_backend/lambda/workspaces_api_resource/workspaces_api_resource_handler.py
@@ -525,7 +525,7 @@ def _workspaces_get(path_params, email):
                     'bmh_workspace_id':path_params['workspace_id'],
                     'user_id':email
                 },
-                ProjectExpression=projection,
+                ProjectionExpression=projection,
                 ExpressionAttributeNames=expression_attribute_names
             )
             retval = response.get('Item', None)


### PR DESCRIPTION
Jira Ticket: [BRH-389](https://ctds-planx.atlassian.net/browse/BRH-389)

### Bug Fixes
* Endpoint `/workspaces/{workspace_id}` with a specific `workspace_id` returns an error [FIXED]

[BRH-389]: https://ctds-planx.atlassian.net/browse/BRH-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ