### PR TITLE
changes for heal admin portal

### DIFF
--- a/bmh_admin_portal_ui/src/components/request-workspace/DirectPay.test.js
+++ b/bmh_admin_portal_ui/src/components/request-workspace/DirectPay.test.js
@@ -48,8 +48,8 @@ const getBillingIDFormData = directPayWrapper => {
     let iifeFunction = (() => {
         return (occHelpURL, method, headers, data, _) => {
             formDataFromState = {
-                "billingID": data.queryStringParameters.brh_data.AGBillingID,
-                "email": data.queryStringParameters.brh_data.Email
+                "billingID": data.queryStringParameters.pp_data.AGBillingID,
+                "email": data.queryStringParameters.pp_data.Email
             }
         }
     })();

--- a/bmh_admin_portal_ui/src/components/request-workspace/direct-pay-form.js
+++ b/bmh_admin_portal_ui/src/components/request-workspace/direct-pay-form.js
@@ -54,7 +54,7 @@ const DirectPayForm = (props) => {
             var data = {
                 "queryStringParameters": {
                     "method": "confirmBillingID",
-                    "brh_data": {
+                    "pp_data": {
                         "AGBillingID": billingID,
                         "Email": email
                     }
@@ -66,7 +66,7 @@ const DirectPayForm = (props) => {
             }
 
             callExternalURL(occHelpURL, "post", headers, data, (response) => {
-                if (response['statusCode'] !== 400 && response.body[0]["Message"]["statusCode"] === 200) {
+                if (response['statusCode'] !== 400 &&  response?.body?.[0]?.Message?.statusCode === 200) {
                     setRequestApproved("true");
                     setDirectPayLimit(response.body[0]["Message"]["body"]);
                     setformDisabled(true);
@@ -127,7 +127,7 @@ const DirectPayForm = (props) => {
             var data = {
                 "queryStringParameters": {
                     "method": "handleRequest",
-                    "brh_data": {
+                    "pp_data": {
                         "AGBillingID": billingID,
                         "Email": email,
                         "ProjectTitle": title,

--- a/bmh_admin_portal_ui/src/views/request-workspace.jsx
+++ b/bmh_admin_portal_ui/src/views/request-workspace.jsx
@@ -86,7 +86,7 @@ const RequestWorkspace = () => {
       <Row className="mb-3"><h4>{"Request Form for OCC Direct Pay Account"}</h4></Row>
       <Row className="justify-content-left">
         <Col>
-          <DirectPayForm />
+          <DirectPayForm updateRedirectHome={setRedirectHome} />
         </Col>
       </Row>
     </div>)


### PR DESCRIPTION
### New Features
Changes for Heal and BMH admin portal

- The name of the key changed from `brh_data` to `pp_data`

### Bug Fixes

- Fixed error for request response, it was showing error in console that line `response.body[0]["Message"]["statusCode"] ` wasn't able to find `statusCode`


### Improvements

- Added `updateRedirectHome` for Direct Pay Form

